### PR TITLE
wt: add "ls" as an alias for "list"

### DIFF
--- a/wt/wt.sh
+++ b/wt/wt.sh
@@ -13,6 +13,7 @@ COMMANDS:
     add [branch] [path]     Create new worktree (auto-generates branch if omitted)
                             Aliases: new, create
     list                    List all worktrees
+                            Aliases: ls
     remove [path]           Remove worktree (current if no path given)
                             Aliases: rm, del, delete
     prune                   Remove stale worktree administrative files
@@ -271,7 +272,7 @@ main() {
         add|new|create)
             cmd_add "$@"
             ;;
-        list)
+        list|ls)
             cmd_list "$@"
             ;;
         remove|rm|del|delete)


### PR DESCRIPTION
## Summary
Adds "ls" as a shorter alias for the "list" command in the wt tool, following the existing pattern of other command aliases like "rm" for remove.

## Test plan
- [x] `wt list` works as before
- [x] `wt ls` works identically to `wt list`
- [x] Help text documents the new alias
- [x] shellcheck passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)