### PR TITLE
wt: suppress fatal error when origin remote doesn't exist

### DIFF
--- a/wt/wt.sh
+++ b/wt/wt.sh
@@ -162,7 +162,7 @@ cmd_add() {
     if git rev-parse --verify "$branch" >/dev/null 2>&1; then
         # Branch exists, check it out
         git worktree add "$path" "$branch"
-    elif git ls-remote --heads origin "$branch" | grep -q "$branch"; then
+    elif git ls-remote --heads origin "$branch" 2>/dev/null | grep -q "$branch"; then
         # Branch exists on remote, track it
         git worktree add "$path" -b "$branch" "origin/$branch"
     else


### PR DESCRIPTION
## Summary
Redirect stderr to /dev/null for git ls-remote check so repositories without an origin remote don't show confusing fatal error messages. The script still works correctly and gracefully falls through to creating a new branch.

## Test plan
- Test `wt add` in a local-only repository (no origin remote)
- Test `wt add` in a repository with an origin remote to ensure no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)