### PR TITLE
wt: add 'world' command to clean up merged worktrees

### DIFF
--- a/wt/README.md
+++ b/wt/README.md
@@ -18,6 +18,7 @@ wt [COMMAND] [OPTIONS]
 - `list` - List all worktrees. Aliases: `ls`
 - `remove [path]` - Remove worktree (current if no path given). Aliases: `rm`, `del`, `delete`
 - `prune` - Remove stale worktree administrative files
+- `world` - Delete worktrees with merged/deleted remote branches
 - `goto [pattern]` - Print path to worktree (interactive with fzf if no pattern)
 - `cd [pattern]` - Change to worktree directory in new shell
 - `cd -` - Change to main worktree
@@ -93,6 +94,12 @@ cd "$(wt goto feature-dragon)"
 Clean up stale worktree data:
 ```bash
 wt prune
+```
+
+Clean up worktrees for merged branches:
+```bash
+wt world
+# Fetches from remotes and removes worktrees whose upstream branches have been deleted
 ```
 
 ## Features


### PR DESCRIPTION
## Summary

Add a new `world` command that deletes worktrees whose upstream tracking branches have been deleted (merged and removed from remote). This mirrors the behavior of the `git world` alias.

## What it does

The command fetches from all remotes, identifies worktrees where the upstream branch no longer exists, and removes them interactively with confirmation. Only worktrees with configured upstreams that are gone are removed.

## Test plan

- Run `wt world` in a repository with merged worktree branches
- Verify it correctly identifies worktrees with deleted upstreams
- Verify interactive confirmation works
- Verify it safely handles being in a worktree that will be removed