### PR TITLE
wt: add 'cleanup' as alias for 'world' command

### DIFF
--- a/wt/wt.sh
+++ b/wt/wt.sh
@@ -18,6 +18,7 @@ COMMANDS:
                             Aliases: rm, del, delete
     prune                   Remove stale worktree administrative files
     world                   Delete worktrees with merged/deleted remote branches
+                            Aliases: cleanup
     goto [pattern]          Print path to worktree (interactive with fzf if no pattern)
     cd [pattern]            Change to worktree directory in new shell
     cd -                    Change to main worktree
@@ -489,7 +490,7 @@ main() {
         prune)
             cmd_prune "$@"
             ;;
-        world)
+        world|cleanup)
             cmd_world "$@"
             ;;
         goto)


### PR DESCRIPTION
## Summary
- Added 'cleanup' as an alias for the 'world' command in the wt script
- Users can now use either `wt world` or `wt cleanup` to clean up worktrees with merged/deleted remote branches
- Updated the command handler and help documentation to reflect the new alias

🤖 Generated with [Claude Code](https://claude.com/claude-code)