### PR TITLE
wt: add 'bd' command as alias for 'remove'

### DIFF
--- a/wt/README.md
+++ b/wt/README.md
@@ -17,7 +17,7 @@ wt [COMMAND] [OPTIONS]
 - `add [branch] [path]` - Create new worktree (auto-generates branch if omitted). Aliases: `new`, `create`
 - `co <pr-number>` - Checkout a PR in a new worktree. Aliases: `checkout`
 - `list` - List all worktrees. Aliases: `ls`
-- `remove [path]` - Remove worktree (current if no path given). Aliases: `rm`, `del`, `delete`
+- `remove [path]` - Remove worktree (current if no path given). Aliases: `rm`, `del`, `delete`, `bd`
 - `prune` - Remove stale worktree administrative files
 - `world` - Delete worktrees with merged/deleted remote branches. Aliases: `cleanup`
 - `goto [pattern]` - Print path to worktree (interactive with fzf if no pattern)

--- a/wt/wt.sh
+++ b/wt/wt.sh
@@ -17,7 +17,7 @@ COMMANDS:
     list                    List all worktrees
                             Aliases: ls
     remove [path]           Remove worktree (current if no path given)
-                            Aliases: rm, del, delete
+                            Aliases: rm, del, delete, bd
     prune                   Remove stale worktree administrative files
     world                   Delete worktrees with merged/deleted remote branches
                             Aliases: cleanup
@@ -622,7 +622,7 @@ main() {
         list|ls)
             cmd_list "$@"
             ;;
-        remove|rm|del|delete)
+        remove|rm|del|delete|bd)
             cmd_remove "$@"
             ;;
         prune)


### PR DESCRIPTION
## Summary

Add 'bd' as a shorter alias for the 'remove' command, complementing the existing 'rm', 'del', and 'delete' aliases.

## Test plan

- Verify 'bd' alias works to remove worktrees
- Confirm help text shows the new alias
- Ensure all pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)