### PR TITLE
cache_prune: add apk and cargo cache cleaning

### DIFF
--- a/APKBUILD
+++ b/APKBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Thiago Perrotta <thiago@perrotta.dev>
 pkgname=pancake
-pkgver=2025.11.23.5
+pkgver=2025.11.28.1
 pkgrel=0
 pkgdesc="A potpourri of sweet ingredients"
 url="https://github.com/thiagowfx/pancake"
@@ -94,5 +94,5 @@ doc() {
 	done
 }
 sha512sums="
-d2b7e613560801b3f37890521ae4d02921f0fdcc02a7af650dee9adc3dd8dc15ea97d2edd50a18b816a4b2510a6d8aac3e580647f92a5bda5698dbe5202a262d  pancake-2025.11.23.5.tar.gz
+bd0d6807c91e934f6670210b3ab284f7a9a5950e6793f16903756a40e24ff20294f900e0a0d1c507bbb62b121f2d59f5e51b4ff1a0247ddca63e30a46cdc3edd  pancake-2025.11.28.1.tar.gz
 "


### PR DESCRIPTION
## Summary
Add support for cleaning APK (Alpine Package Keeper) and Cargo (Rust package manager) caches. APK uses the native `apk cache clean` command, while Cargo supports both the cargo-cache tool and a fallback manual cleanup. Update APKBUILD to version 2025.11.28.1 to include cache_prune in Alpine packages.

## Test plan
- Verify script syntax with `bash -n`
- Test help output includes apk and cargo
- Test dry-run mode shows what would be cleaned
- Confirm pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)